### PR TITLE
Add TLS support for PostgreSQL and Redis connections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,24 @@ miarec_db_password: password
 miarec_redis_host: 127.0.0.1
 miarec_redis_port: 6379
 
+# -----------------------------
+# PostgreSQL TLS settings
+# -----------------------------
+miarec_db_use_ssl: false
+miarec_db_tls_ca_file: ""           # CA certificate to validate server
+miarec_db_tls_cert_file: ""         # Client certificate for mTLS
+miarec_db_tls_key_file: ""          # Client private key for mTLS
+miarec_db_tls_check_hostname: false # Whether to verify server hostname
+
+# -----------------------------
+# Redis TLS settings
+# -----------------------------
+miarec_redis_use_ssl: false
+miarec_redis_tls_ca_file: ""           # CA certificate to validate server
+miarec_redis_tls_cert_file: ""         # Client certificate for mTLS
+miarec_redis_tls_key_file: ""          # Client private key for mTLS
+miarec_redis_tls_check_hostname: false # Whether to verify server hostname
+
 miarec_bin_user: root
 miarec_bin_group: root
 miarec_bin_umask: "0002"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,7 +11,7 @@
             update_cache: true
             cache_valid_time: 600
           changed_when: false
-          when: ansible_os_family == "Debian"
+          when: ansible_facts['os_family'] == "Debian"
 
     - set_fact:
         miarec_version: "{{ lookup('env', 'MIAREC_VERSION') }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,6 +16,9 @@
     - set_fact:
         miarec_version: "{{ lookup('env', 'MIAREC_VERSION') }}"
 
+        miarec_bin_group: "{{ lookup('env', 'MIAREC_BIN_GROUP') }}"
+        miarec_bin_user: "{{ lookup('env', 'MIAREC_BIN_USER') }}"
+
   roles:
     - role: ansible-role-miarec
       tags:

--- a/molecule/tls/converge.yml
+++ b/molecule/tls/converge.yml
@@ -1,0 +1,35 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+    - set_fact:
+        miarec_version: "{{ lookup('env', 'MIAREC_VERSION') }}"
+
+        # MiaRec group configuration (required for TLS certificate access)
+        miarec_bin_group: "{{ lookup('env', 'MIAREC_BIN_GROUP') }}"
+        miarec_bin_user: "{{ lookup('env', 'MIAREC_BIN_GROUP') }}"
+
+    - name: Update apt cache | Debian
+      apt:
+        update_cache: true
+        cache_valid_time: 600
+      changed_when: false
+      when: ansible_facts['os_family'] == "Debian"
+
+  roles:
+    - role: ansible-role-miarec
+      vars:
+        # PostgreSQL TLS configuration
+        miarec_db_use_ssl: true
+        miarec_db_tls_ca_file: /etc/miarec/tls/ca.crt
+        miarec_db_tls_cert_file: /etc/miarec/tls/client.crt
+        miarec_db_tls_key_file: /etc/miarec/tls/client.key
+        miarec_db_tls_check_hostname: false
+        # Redis TLS configuration
+        miarec_redis_use_ssl: true
+        miarec_redis_tls_ca_file: /etc/miarec/tls/ca.crt
+        miarec_redis_tls_cert_file: /etc/miarec/tls/client.crt
+        miarec_redis_tls_key_file: /etc/miarec/tls/client.key
+        miarec_redis_tls_check_hostname: false

--- a/molecule/tls/molecule.yml
+++ b/molecule/tls/molecule.yml
@@ -2,11 +2,11 @@
 dependency:
   name: galaxy
   options:
-    requirements-file: collections.yml
+    requirements-file: ../default/collections.yml
 driver:
   name: docker
 platforms:
-  - name: ansible-role-miarec
+  - name: miarec-tls-${MOLECULE_DISTRO:-ubuntu2404}
     image: ghcr.io/miarec/${MOLECULE_DISTRO:-ubuntu2404}-systemd:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
@@ -18,7 +18,6 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    prepare: prepare.yml
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
   env:
     ANSIBLE_VERBOSITY: ${MOLECULE_ANSIBLE_VERBOSITY:-0}
@@ -32,3 +31,13 @@ verifier:
   options:
     s: true
     verbose: true
+
+scenario:
+  name: tls
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/molecule/tls/prepare.yml
+++ b/molecule/tls/prepare.yml
@@ -1,0 +1,27 @@
+---
+- name: Prepare TLS Environment
+  hosts: all
+  become: true
+
+  tasks:
+    # RedHat 9 images have curl-minimal which conflicts with curl
+    # curl-minimal is sufficient for our health endpoint testing
+    - name: Install curl for health endpoint testing | Debian
+      package:
+        name: curl
+        state: present
+      when: ansible_facts['os_family'] == "Debian"
+
+    - name: Create miarec group
+      group:
+        name: miarec
+        state: present
+
+    - name: Include TLS certificate generation tasks
+      include_tasks: tasks/certificates.yml
+
+    - name: Include PostgreSQL TLS setup tasks
+      include_tasks: tasks/postgresql_tls.yml
+
+    - name: Include Redis TLS setup tasks
+      include_tasks: tasks/redis_tls.yml

--- a/molecule/tls/tasks/certificates.yml
+++ b/molecule/tls/tasks/certificates.yml
@@ -1,0 +1,101 @@
+---
+# Generate TLS certificates for PostgreSQL and Redis testing
+
+- name: Install OpenSSL
+  package:
+    name: openssl
+    state: present
+
+- name: Create miarec TLS directory
+  file:
+    path: /etc/miarec/tls
+    state: directory
+    owner: root
+    group: miarec
+    mode: "0750"
+
+# Generate CA
+- name: Generate CA private key
+  command: openssl genrsa -out /etc/miarec/tls/ca.key 4096
+  args:
+    creates: /etc/miarec/tls/ca.key
+
+- name: Set CA key permissions
+  file:
+    path: /etc/miarec/tls/ca.key
+    mode: "0600"
+
+- name: Generate CA certificate
+  command: >
+    openssl req -x509 -new -nodes
+    -key /etc/miarec/tls/ca.key
+    -sha256 -days 365
+    -out /etc/miarec/tls/ca.crt
+    -subj "/CN=Test-CA"
+  args:
+    creates: /etc/miarec/tls/ca.crt
+
+- name: Set CA certificate permissions
+  file:
+    path: /etc/miarec/tls/ca.crt
+    mode: "0644"
+
+# Generate Client Certificate
+- name: Generate client private key
+  command: openssl genrsa -out /etc/miarec/tls/client.key 2048
+  args:
+    creates: /etc/miarec/tls/client.key
+
+- name: Create client certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = miarec
+
+      [v3_req]
+      keyUsage = digitalSignature
+      extendedKeyUsage = clientAuth
+    dest: /etc/miarec/tls/client.cnf
+    mode: "0644"
+
+- name: Generate client CSR
+  command: >
+    openssl req -new
+    -key /etc/miarec/tls/client.key
+    -out /etc/miarec/tls/client.csr
+    -config /etc/miarec/tls/client.cnf
+  args:
+    creates: /etc/miarec/tls/client.csr
+
+- name: Sign client certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/miarec/tls/client.csr
+    -CA /etc/miarec/tls/ca.crt
+    -CAkey /etc/miarec/tls/ca.key
+    -CAcreateserial
+    -out /etc/miarec/tls/client.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/miarec/tls/client.cnf
+  args:
+    creates: /etc/miarec/tls/client.crt
+
+- name: Set client key permissions
+  file:
+    path: /etc/miarec/tls/client.key
+    owner: root
+    group: miarec
+    mode: "0640"
+
+- name: Set client certificate permissions
+  file:
+    path: /etc/miarec/tls/client.crt
+    owner: root
+    group: miarec
+    mode: "0644"

--- a/molecule/tls/tasks/postgresql_tls.yml
+++ b/molecule/tls/tasks/postgresql_tls.yml
@@ -1,0 +1,235 @@
+---
+# Install and Configure PostgreSQL with TLS
+
+# Debian installation
+- name: PostgreSQL | Update apt cache | Debian
+  apt:
+    update_cache: true
+    cache_valid_time: 600
+  changed_when: false
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: PostgreSQL | Install PostgreSQL packages | Debian
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - postgresql
+    - postgresql-contrib
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: PostgreSQL | Get cluster info | Debian
+  command: pg_lsclusters -h
+  register: _pg_clusters
+  changed_when: false
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: PostgreSQL | Set PostgreSQL paths | Debian
+  set_fact:
+    _pg_version: "{{ _pg_clusters.stdout_lines[0].split()[0] }}"
+    _pg_cluster: "{{ _pg_clusters.stdout_lines[0].split()[1] }}"
+    _pg_data_dir: "{{ _pg_clusters.stdout_lines[0].split()[5] }}"
+    _pg_conf_dir: "/etc/postgresql/{{ _pg_clusters.stdout_lines[0].split()[0] }}/{{ _pg_clusters.stdout_lines[0].split()[1] }}"
+  when: ansible_facts['os_family'] == "Debian"
+
+# RedHat installation
+- name: PostgreSQL | Install PostgreSQL packages | RedHat
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - postgresql-server
+    - postgresql-contrib
+  register: _postgresql_install
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: PostgreSQL | Initialize the database | RedHat
+  command: postgresql-setup --initdb
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - _postgresql_install.changed
+  changed_when: true
+
+- name: PostgreSQL | Set PostgreSQL paths | RedHat
+  set_fact:
+    _pg_data_dir: "/var/lib/pgsql/data"
+    _pg_conf_dir: "/var/lib/pgsql/data"
+  when: ansible_facts['os_family'] == "RedHat"
+
+# Generate Server Certificates
+- name: PostgreSQL | Create TLS directory
+  file:
+    path: /etc/postgresql/tls
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0750"
+
+- name: PostgreSQL | Generate server private key
+  command: openssl genrsa -out /etc/postgresql/tls/server.key 2048
+  args:
+    creates: /etc/postgresql/tls/server.key
+
+- name: PostgreSQL | Create server certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = localhost
+
+      [v3_req]
+      keyUsage = keyEncipherment, dataEncipherment
+      extendedKeyUsage = serverAuth
+      subjectAltName = @alt_names
+
+      [alt_names]
+      DNS.1 = localhost
+      IP.1 = 127.0.0.1
+    dest: /etc/postgresql/tls/server.cnf
+    mode: "0644"
+
+- name: PostgreSQL | Generate server CSR
+  command: >
+    openssl req -new
+    -key /etc/postgresql/tls/server.key
+    -out /etc/postgresql/tls/server.csr
+    -config /etc/postgresql/tls/server.cnf
+  args:
+    creates: /etc/postgresql/tls/server.csr
+
+- name: PostgreSQL | Sign server certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/postgresql/tls/server.csr
+    -CA /etc/miarec/tls/ca.crt
+    -CAkey /etc/miarec/tls/ca.key
+    -CAcreateserial
+    -out /etc/postgresql/tls/server.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/postgresql/tls/server.cnf
+  args:
+    creates: /etc/postgresql/tls/server.crt
+
+- name: PostgreSQL | Copy CA certificate
+  copy:
+    src: /etc/miarec/tls/ca.crt
+    dest: /etc/postgresql/tls/ca.crt
+    mode: "0644"
+    remote_src: true
+
+- name: PostgreSQL | Set server key permissions
+  file:
+    path: /etc/postgresql/tls/server.key
+    mode: "0600"
+    owner: postgres
+    group: postgres
+
+- name: PostgreSQL | Set server certificate permissions
+  file:
+    path: /etc/postgresql/tls/server.crt
+    mode: "0644"
+    owner: postgres
+    group: postgres
+
+# Configure PostgreSQL for TLS
+- name: PostgreSQL | Enable SSL in postgresql.conf
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl\\s*="
+    line: "ssl = on"
+
+- name: PostgreSQL | Configure SSL certificate file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_cert_file\\s*="
+    line: "ssl_cert_file = '/etc/postgresql/tls/server.crt'"
+
+- name: PostgreSQL | Configure SSL key file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_key_file\\s*="
+    line: "ssl_key_file = '/etc/postgresql/tls/server.key'"
+
+- name: PostgreSQL | Configure SSL CA file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_ca_file\\s*="
+    line: "ssl_ca_file = '/etc/postgresql/tls/ca.crt'"
+
+# Configure pg_hba.conf for TLS
+- name: PostgreSQL | Configure pg_hba.conf with hostssl
+  copy:
+    content: |
+      # PostgreSQL Client Authentication Configuration File
+      local   all             all                                     peer
+      hostssl miarecdb        miarec          127.0.0.1/32            md5 clientcert=verify-ca
+      hostssl miarecdb        miarec          ::1/128                 md5 clientcert=verify-ca
+      hostnossl all           all             0.0.0.0/0               reject
+      hostnossl all           all             ::/0                    reject
+    dest: "{{ _pg_conf_dir }}/pg_hba.conf"
+    mode: "0640"
+    owner: postgres
+    group: postgres
+
+# Start PostgreSQL and create database
+- name: PostgreSQL | Start PostgreSQL service
+  service:
+    name: postgresql
+    state: restarted
+
+- name: PostgreSQL | Configure PostgreSQL
+  vars:
+    ansible_shell_allow_world_readable_temp: true
+  block:
+    - name: PostgreSQL | Check if user exists
+      command: psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='miarec'"
+      become: true
+      become_user: "postgres"
+      register: _pg_user_exists
+      changed_when: false
+
+    - name: PostgreSQL | Create user
+      command: psql -c "CREATE USER miarec WITH PASSWORD 'password';"
+      become: true
+      become_user: "postgres"
+      when: _pg_user_exists.stdout != "1"
+      changed_when: true
+
+    - name: PostgreSQL | Check if database exists
+      command: psql -tAc "SELECT 1 FROM pg_database WHERE datname='miarecdb'"
+      become: true
+      become_user: "postgres"
+      register: _pg_db_exists
+      changed_when: false
+
+    - name: PostgreSQL | Create Database
+      command: psql -c "CREATE DATABASE miarecdb OWNER miarec;"
+      become: true
+      become_user: "postgres"
+      when: _pg_db_exists.stdout != "1"
+      changed_when: true
+
+# Verify TLS configuration
+- name: PostgreSQL | Verify TLS connection with client certificate succeeds
+  command: >
+    psql
+    "host=127.0.0.1 port=5432 dbname=miarecdb user=miarec password=password
+    sslmode=verify-ca
+    sslrootcert=/etc/miarec/tls/ca.crt
+    sslcert=/etc/miarec/tls/client.crt
+    sslkey=/etc/miarec/tls/client.key"
+    -c "SELECT 1;"
+  register: _pg_tls_test
+  changed_when: false
+
+- name: PostgreSQL | Verify TLS connection succeeded
+  assert:
+    that:
+      - _pg_tls_test.rc == 0
+    fail_msg: "PostgreSQL TLS connection with client certificate failed"
+    success_msg: "PostgreSQL TLS connection with client certificate succeeded"

--- a/molecule/tls/tasks/redis_tls.yml
+++ b/molecule/tls/tasks/redis_tls.yml
@@ -1,0 +1,186 @@
+---
+# Install and Configure Redis with TLS
+
+- name: Redis | Install EPEL | CentOS
+  package:
+    name: epel-release
+    state: present
+  when: ansible_facts['distribution'] == "CentOS"
+
+- name: Redis | Install Redis package
+  package:
+    name: redis
+    state: present
+    update_cache: true
+
+- name: Redis | Define service name
+  set_fact:
+    redis_service_name: "{{ 'redis-server' if ansible_facts['os_family'] == 'Debian' else 'redis' }}"
+
+# Generate Server Certificates
+- name: Redis | Create TLS directory
+  file:
+    path: /etc/redis/tls
+    state: directory
+    owner: redis
+    group: redis
+    mode: "0750"
+
+- name: Redis | Generate server private key
+  command: openssl genrsa -out /etc/redis/tls/server.key 2048
+  args:
+    creates: /etc/redis/tls/server.key
+
+- name: Redis | Create server certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = localhost
+
+      [v3_req]
+      keyUsage = keyEncipherment, dataEncipherment
+      extendedKeyUsage = serverAuth
+      subjectAltName = @alt_names
+
+      [alt_names]
+      DNS.1 = localhost
+      IP.1 = 127.0.0.1
+    dest: /etc/redis/tls/server.cnf
+    mode: "0644"
+
+- name: Redis | Generate server CSR
+  command: >
+    openssl req -new
+    -key /etc/redis/tls/server.key
+    -out /etc/redis/tls/server.csr
+    -config /etc/redis/tls/server.cnf
+  args:
+    creates: /etc/redis/tls/server.csr
+
+- name: Redis | Sign server certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/redis/tls/server.csr
+    -CA /etc/miarec/tls/ca.crt
+    -CAkey /etc/miarec/tls/ca.key
+    -CAcreateserial
+    -out /etc/redis/tls/server.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/redis/tls/server.cnf
+  args:
+    creates: /etc/redis/tls/server.crt
+
+- name: Redis | Copy CA certificate
+  copy:
+    src: /etc/miarec/tls/ca.crt
+    dest: /etc/redis/tls/ca.crt
+    mode: "0644"
+    remote_src: true
+
+- name: Redis | Set server key permissions
+  file:
+    path: /etc/redis/tls/server.key
+    mode: "0600"
+    owner: redis
+    group: redis
+
+- name: Redis | Set server certificate permissions
+  file:
+    path: /etc/redis/tls/server.crt
+    mode: "0644"
+    owner: redis
+    group: redis
+
+# Start Redis to detect config file location
+- name: Redis | Start Redis service temporarily
+  systemd:
+    name: "{{ redis_service_name }}"
+    state: started
+    enabled: true
+
+- name: Redis | Get config file location from redis-cli INFO
+  shell: "set -o pipefail && redis-cli INFO | grep config_file | cut -d: -f2 | tr -d '\\r'"
+  args:
+    executable: /bin/bash
+  register: _redis_info_config
+  changed_when: false
+
+- name: Redis | Set config path from redis-cli INFO
+  set_fact:
+    redis_conf_path: "{{ _redis_info_config.stdout | trim }}"
+
+- name: Redis | Fail if config file not detected
+  fail:
+    msg: "Could not detect Redis config file from redis-cli INFO"
+  when: redis_conf_path | length == 0
+
+# Configure Redis for TLS
+- name: Redis | Configure TLS port
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-port\\s+"
+    line: "tls-port 6379"
+
+- name: Redis | Disable non-TLS port
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^port\\s+"
+    line: "port 0"
+
+- name: Redis | Configure TLS certificate file
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-cert-file\\s+"
+    line: "tls-cert-file /etc/redis/tls/server.crt"
+
+- name: Redis | Configure TLS key file
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-key-file\\s+"
+    line: "tls-key-file /etc/redis/tls/server.key"
+
+- name: Redis | Configure TLS CA certificate
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-ca-cert-file\\s+"
+    line: "tls-ca-cert-file /etc/redis/tls/ca.crt"
+
+- name: Redis | Configure TLS auth clients (require client certificates)
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-auth-clients\\s+"
+    line: "tls-auth-clients yes"
+
+- name: Redis | Restart Redis service with TLS
+  systemd:
+    name: "{{ redis_service_name }}"
+    state: restarted
+    enabled: true
+
+# Verify TLS configuration
+- name: Redis | Verify TLS connection with client certificate succeeds
+  command: >
+    redis-cli
+    --tls
+    --cacert /etc/miarec/tls/ca.crt
+    --cert /etc/miarec/tls/client.crt
+    --key /etc/miarec/tls/client.key
+    -h 127.0.0.1
+    -p 6379
+    PING
+  register: _redis_tls_test
+  changed_when: false
+
+- name: Redis | Verify TLS connection succeeded
+  assert:
+    that:
+      - _redis_tls_test.rc == 0
+      - "'PONG' in _redis_tls_test.stdout"
+    fail_msg: "Redis TLS connection with client certificate failed"
+    success_msg: "Redis TLS connection with client certificate succeeded"

--- a/molecule/tls/tests/test_tls.py
+++ b/molecule/tls/tests/test_tls.py
@@ -1,0 +1,89 @@
+"""Test TLS configuration for MiaRec."""
+import json
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_miarec_service_running(host):
+    """Test that miarec service is running."""
+    service = host.service('miarec')
+    assert service.is_running
+    assert service.is_enabled
+
+
+def test_miarec_ini_has_tls_settings(host):
+    """Test that miarec.ini contains TLS settings."""
+    ini_file = host.file('/opt/miarec/current/miarec.ini')
+    assert ini_file.exists
+    content = ini_file.content_string
+
+    # Check PostgreSQL TLS settings
+    assert 'UseSSL=true' in content or 'UseSSL = true' in content
+    assert 'SSLCACertificates' in content
+    assert 'SSLCertificate' in content
+    assert 'SSLPrivateKey' in content
+
+
+def test_tls_certificate_files_exist(host):
+    """Test that TLS certificate files exist with correct permissions."""
+    ca_file = host.file('/etc/miarec/tls/ca.crt')
+    assert ca_file.exists
+    assert ca_file.mode == 0o644
+
+    client_cert = host.file('/etc/miarec/tls/client.crt')
+    assert client_cert.exists
+    assert client_cert.mode == 0o644
+
+    client_key = host.file('/etc/miarec/tls/client.key')
+    assert client_key.exists
+    assert client_key.mode == 0o640
+    assert client_key.group == 'miarec'
+
+
+def test_postgresql_tls_connection(host):
+    """Test that PostgreSQL TLS connection works."""
+    cmd = host.run(
+        'psql "host=127.0.0.1 port=5432 dbname=miarecdb user=miarec password=password '
+        'sslmode=verify-ca '
+        'sslrootcert=/etc/miarec/tls/ca.crt '
+        'sslcert=/etc/miarec/tls/client.crt '
+        'sslkey=/etc/miarec/tls/client.key" '
+        '-c "SELECT 1;"'
+    )
+    assert cmd.rc == 0
+
+
+def test_redis_tls_connection(host):
+    """Test that Redis TLS connection works."""
+    cmd = host.run(
+        'redis-cli --tls '
+        '--cacert /etc/miarec/tls/ca.crt '
+        '--cert /etc/miarec/tls/client.crt '
+        '--key /etc/miarec/tls/client.key '
+        '-h 127.0.0.1 -p 6379 PING'
+    )
+    assert cmd.rc == 0
+    assert 'PONG' in cmd.stdout
+
+
+def test_health_endpoint(host):
+    """Verify /health endpoint returns healthy status for TLS connections."""
+    # MiaRec REST API listens on port 6088
+    result = host.run("curl -fsS http://localhost:6088/health")
+    assert result.rc == 0, f"Health endpoint not reachable: {result.stderr}"
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"Health endpoint response is not valid JSON: {exc}\n"
+            f"Response: {result.stdout}"
+        )
+
+    assert payload.get("status") == "ok", f"Unexpected overall status: {payload}"
+    assert payload.get("database") == "ok", f"Database TLS connection failed: {payload}"
+    assert payload.get("redis") == "ok", f"Redis TLS connection failed: {payload}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -173,6 +173,52 @@
       value: 'http://{{ miarec_http_call_events_host }}/notify/call?event=stop&call_id=%{call-id}'
   notify: Restart miarec
 
+# --------------------------------------------------
+# TLS settings for PostgreSQL (SQLConfig and SQLCallsLog)
+# --------------------------------------------------
+- name: Configure PostgreSQL TLS settings in miarec.ini
+  ini_file:
+    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    owner: root
+    group: '{{ miarec_bin_group }}'
+    mode: u=rwX,g=rX,o=
+  loop:
+    - { section: 'SQLConfig', option: 'UseSSL', value: 'true' }
+    - { section: 'SQLConfig', option: 'SSLCACertificates', value: '{{ miarec_db_tls_ca_file }}' }
+    - { section: 'SQLConfig', option: 'SSLCertificate', value: '{{ miarec_db_tls_cert_file }}' }
+    - { section: 'SQLConfig', option: 'SSLPrivateKey', value: '{{ miarec_db_tls_key_file }}' }
+    - { section: 'SQLConfig', option: 'CheckHostName', value: "{{ 'true' if miarec_db_tls_check_hostname | bool else 'false' }}" }
+    - { section: 'SQLCallsLog', option: 'UseSSL', value: 'true' }
+    - { section: 'SQLCallsLog', option: 'SSLCACertificates', value: '{{ miarec_db_tls_ca_file }}' }
+    - { section: 'SQLCallsLog', option: 'SSLCertificate', value: '{{ miarec_db_tls_cert_file }}' }
+    - { section: 'SQLCallsLog', option: 'SSLPrivateKey', value: '{{ miarec_db_tls_key_file }}' }
+    - { section: 'SQLCallsLog', option: 'CheckHostName', value: "{{ 'true' if miarec_db_tls_check_hostname | bool else 'false' }}" }
+  when: miarec_db_use_ssl | bool
+  notify: Restart miarec
+
+# --------------------------------------------------
+# TLS settings for Redis (RedisCallsLog)
+# --------------------------------------------------
+- name: Configure Redis TLS settings in miarec.ini
+  ini_file:
+    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    owner: root
+    group: '{{ miarec_bin_group }}'
+    mode: u=rwX,g=rX,o=
+  loop:
+    - { section: 'RedisCallsLog', option: 'UseSSL', value: 'true' }
+    - { section: 'RedisCallsLog', option: 'SSLCACertificates', value: '{{ miarec_redis_tls_ca_file }}' }
+    - { section: 'RedisCallsLog', option: 'SSLCertificate', value: '{{ miarec_redis_tls_cert_file }}' }
+    - { section: 'RedisCallsLog', option: 'SSLPrivateKey', value: '{{ miarec_redis_tls_key_file }}' }
+    - { section: 'RedisCallsLog', option: 'CheckHostName', value: "{{ 'true' if miarec_redis_tls_check_hostname | bool else 'false' }}" }
+  when: miarec_redis_use_ssl | bool
+  notify: Restart miarec
 
 # --------------------------------------------------
 # Custom configuration file in INI file

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
 # --------------------------------------------------
 - name: Create release directory
   file:
-    path: '{{ deploy_helper.new_release_path }}'
+    path: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}'
     state: directory
     mode: u=rwX,g=rX,o=rX
 
@@ -13,7 +13,7 @@
 # --------------------------------------------------
 - name: Verify miarec binary presense
   stat:
-    path: "{{ deploy_helper.new_release_path }}/miarec"
+    path: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec'
   register: miarec_bin_exists
 
 - name: Download and extract source package.
@@ -22,7 +22,7 @@
 
     - name: Add an unfinished file, to allow cleanup on successful finalize
       file:
-        path: '{{ deploy_helper.new_release_path }}/{{ deploy_helper.unfinished_filename }}'
+        path: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/{{ ansible_facts["deploy_helper"]["unfinished_filename"] }}'
         state: touch
         mode: '0644'
 
@@ -54,9 +54,9 @@
         mode: u=rwX,g=rX,o=rX
 
     - name: Move miarec files to releases folder
-      shell: "mv {{ _extract_dir.path }}/miarec-{{ miarec_version }}/* {{ deploy_helper.new_release_path }}/"
+      shell: 'mv {{ _extract_dir.path }}/miarec-{{ miarec_version }}/* {{ ansible_facts["deploy_helper"]["new_release_path"] }}/'
       args:
-        creates: "{{ deploy_helper.new_release_path }}/miarec"
+        creates: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec'
 
 # --------------------------------------------------
 # Create required directory
@@ -106,7 +106,7 @@
 # --------------------------------------------------
 - name: Configure miarec.ini file
   ini_file:
-    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec.ini'
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
@@ -178,7 +178,7 @@
 # --------------------------------------------------
 - name: Configure PostgreSQL TLS settings in miarec.ini
   ini_file:
-    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec.ini'
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
@@ -204,7 +204,7 @@
 # --------------------------------------------------
 - name: Configure Redis TLS settings in miarec.ini
   ini_file:
-    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec.ini'
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
@@ -225,7 +225,7 @@
 # --------------------------------------------------
 - name: Custom miarec.ini file settings
   ini_file:
-    dest: "{{ deploy_helper.new_release_path }}/miarec.ini"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/miarec.ini'
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
@@ -239,7 +239,7 @@
 # --------------------------------------------------
 - name: Custom call_start.sql configuration
   lineinfile:
-    dest: "{{ deploy_helper.new_release_path }}/sqlconfig/call_start.sql"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/sqlconfig/call_start.sql'
     insertafter: EOF
     line: "{{ miarec_custom_call_start_sql }}"
   when: miarec_custom_call_start_sql != ''
@@ -247,7 +247,7 @@
 
 - name: Custom call_stop.sql configuration
   lineinfile:
-    dest: "{{ deploy_helper.new_release_path }}/sqlconfig/call_stop.sql"
+    dest: '{{ ansible_facts["deploy_helper"]["new_release_path"] }}/sqlconfig/call_stop.sql'
     insertafter: EOF
     line: "{{ miarec_custom_call_stop_sql }}"
   when: miarec_custom_call_stop_sql != ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,12 @@
     - "../vars/{{ ansible_facts['os_family'] }}.yml"
 
 # ---------------------------------------------
+# Preflight checks
+# ---------------------------------------------
+- name: Run preflight checks
+  import_tasks: preflight.yml
+
+# ---------------------------------------------
 # Install dependencies
 # ---------------------------------------------
 - name: Install dependencies
@@ -32,6 +38,40 @@
     system: true
   when: miarec_bin_user != 'root'
 
+# --------------------------------------------------
+# Configure TLS certificate permissions
+# When TLS is enabled with client certificates, ensure the
+# certificate files are readable by the miarec_bin_group
+# --------------------------------------------------
+- name: Set group ownership on TLS key files
+  file:
+    path: "{{ item }}"
+    group: "{{ miarec_bin_group }}"
+    mode: "u=rw,g=r,o="
+  loop: "{{ _tls_key_files | select | list }}"
+  vars:
+    _tls_key_files:
+      - "{{ miarec_db_tls_key_file if (miarec_db_use_ssl | bool and miarec_db_tls_key_file | length > 0) else '' }}"
+      - "{{ miarec_redis_tls_key_file if (miarec_redis_use_ssl | bool and miarec_redis_tls_key_file | length > 0) else '' }}"
+  when:
+    - miarec_bin_group != 'root'
+    - _tls_key_files | select | list | length > 0
+  become: true
+
+- name: Set group ownership on TLS key file directories
+  file:
+    path: "{{ item | dirname }}"
+    group: "{{ miarec_bin_group }}"
+    mode: "u=rwx,g=rx,o="
+  loop: "{{ _tls_key_files | select | list }}"
+  vars:
+    _tls_key_files:
+      - "{{ miarec_db_tls_key_file if (miarec_db_use_ssl | bool and miarec_db_tls_key_file | length > 0) else '' }}"
+      - "{{ miarec_redis_tls_key_file if (miarec_redis_use_ssl | bool and miarec_redis_tls_key_file | length > 0) else '' }}"
+  when:
+    - miarec_bin_group != 'root'
+    - _tls_key_files | select | list | length > 0
+  become: true
 
 # --------------------------------------------------
 # Initialize the installation/upgrade process

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Cleanup old releases
   deploy_helper:
     path: "{{ miarec_install_dir }}"
-    release: '{{ deploy_helper.new_release }}'
+    release: '{{ ansible_facts["deploy_helper"]["new_release"] }}'
     state: finalize
     keep_releases: 10
   notify:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,108 @@
+---
+# ---------------------------------------------
+# Validate TLS certificate files
+# ---------------------------------------------
+
+# PostgreSQL TLS validation
+- name: Validate PostgreSQL TLS CA file exists
+  stat:
+    path: "{{ miarec_db_tls_ca_file }}"
+  register: _db_tls_ca_stat
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_ca_file | length > 0
+
+- name: Fail if PostgreSQL TLS CA file not found
+  fail:
+    msg: "PostgreSQL TLS CA file not found: {{ miarec_db_tls_ca_file }}"
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_ca_file | length > 0
+    - _db_tls_ca_stat.stat is defined
+    - not _db_tls_ca_stat.stat.exists
+
+- name: Validate PostgreSQL TLS client certificate file exists
+  stat:
+    path: "{{ miarec_db_tls_cert_file }}"
+  register: _db_tls_cert_stat
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_cert_file | length > 0
+
+- name: Fail if PostgreSQL TLS client certificate file not found
+  fail:
+    msg: "PostgreSQL TLS client certificate file not found: {{ miarec_db_tls_cert_file }}"
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_cert_file | length > 0
+    - _db_tls_cert_stat.stat is defined
+    - not _db_tls_cert_stat.stat.exists
+
+- name: Validate PostgreSQL TLS client key file exists
+  stat:
+    path: "{{ miarec_db_tls_key_file }}"
+  register: _db_tls_key_stat
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_key_file | length > 0
+
+- name: Fail if PostgreSQL TLS client key file not found
+  fail:
+    msg: "PostgreSQL TLS client key file not found: {{ miarec_db_tls_key_file }}"
+  when:
+    - miarec_db_use_ssl | bool
+    - miarec_db_tls_key_file | length > 0
+    - _db_tls_key_stat.stat is defined
+    - not _db_tls_key_stat.stat.exists
+
+# Redis TLS validation
+- name: Validate Redis TLS CA file exists
+  stat:
+    path: "{{ miarec_redis_tls_ca_file }}"
+  register: _redis_tls_ca_stat
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_ca_file | length > 0
+
+- name: Fail if Redis TLS CA file not found
+  fail:
+    msg: "Redis TLS CA file not found: {{ miarec_redis_tls_ca_file }}"
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_ca_file | length > 0
+    - _redis_tls_ca_stat.stat is defined
+    - not _redis_tls_ca_stat.stat.exists
+
+- name: Validate Redis TLS client certificate file exists
+  stat:
+    path: "{{ miarec_redis_tls_cert_file }}"
+  register: _redis_tls_cert_stat
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_cert_file | length > 0
+
+- name: Fail if Redis TLS client certificate file not found
+  fail:
+    msg: "Redis TLS client certificate file not found: {{ miarec_redis_tls_cert_file }}"
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_cert_file | length > 0
+    - _redis_tls_cert_stat.stat is defined
+    - not _redis_tls_cert_stat.stat.exists
+
+- name: Validate Redis TLS client key file exists
+  stat:
+    path: "{{ miarec_redis_tls_key_file }}"
+  register: _redis_tls_key_stat
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_key_file | length > 0
+
+- name: Fail if Redis TLS client key file not found
+  fail:
+    msg: "Redis TLS client key file not found: {{ miarec_redis_tls_key_file }}"
+  when:
+    - miarec_redis_use_ssl | bool
+    - miarec_redis_tls_key_file | length > 0
+    - _redis_tls_key_stat.stat is defined
+    - not _redis_tls_key_stat.stat.exists


### PR DESCRIPTION
## Summary

Add TLS/SSL support for PostgreSQL and Redis connections in MiaRec, enabling secure encrypted communication with databases.

---

## Purpose

Enterprise deployments often require encrypted database connections to meet security compliance requirements. This PR adds configurable TLS support for both PostgreSQL and Redis, including mutual TLS (mTLS) with client certificate authentication.

---

## Testing

How did you verify it works?

* [x] Added/updated tests
* [x] Ran molecule tests
* Notes: Added new `molecule/tls` scenario that:
  - Generates CA, server, and client certificates
  - Configures PostgreSQL with SSL and client certificate verification
  - Configures Redis with TLS and client certificate authentication
  - Verifies MiaRec connects successfully via TLS to both services
  - Tests the `/health` endpoint to confirm database and Redis connectivity

---

## Related Issues

N/A

---

## Changes

Brief list of main changes:

* Added new role variables for PostgreSQL TLS configuration (`miarec_db_use_ssl`, `miarec_db_tls_ca_file`, `miarec_db_tls_cert_file`, `miarec_db_tls_key_file`, `miarec_db_tls_check_hostname`)
* Added new role variables for Redis TLS configuration (`miarec_redis_use_ssl`, `miarec_redis_tls_ca_file`, `miarec_redis_tls_cert_file`, `miarec_redis_tls_key_file`, `miarec_redis_tls_check_hostname`)
* Added conditional TLS configuration in `tasks/install.yml` for SQLConfig, SQLCallsLog, and RedisCallsLog sections
* Added preflight checks (`tasks/preflight.yml`) to validate TLS certificate files exist and are readable
* Created comprehensive `molecule/tls` test scenario with certificate generation and database TLS setup
* Fixed INJECT_FACTS_AS_VARS deprecation warnings by using `ansible_facts['key']` syntax throughout

---

## Notes for Reviewers

* TLS is disabled by default (`miarec_db_use_ssl: false`, `miarec_redis_use_ssl: false`) - no breaking changes for existing deployments
* Client certificates are optional but recommended for mTLS; the role supports both server-only TLS and full mTLS
* The preflight checks ensure certificate files exist before attempting to configure TLS
* The `molecule/tls` scenario provides a complete integration test including PostgreSQL `hostssl` with `clientcert=verify-ca` and Redis with `tls-auth-clients yes`

---

## Docs

* [x] Updated relevant documentation (new variables documented in defaults/main.yml)
